### PR TITLE
[Builder] #6: Add stars badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ Edit `content/topics.txt` and add one topic per line.
 - Vercel (hosting + cron)
 
 Total lines of code: ~450 (excluding node_modules)
+
+[![GitHub stars](https://img.shields.io/github/stars/derrybirkett/anna?style=social)](https://github.com/derrybirkett/anna)


### PR DESCRIPTION
## What
Adds GitHub stars badge to README (issue #6)

## Why
Improves social proof and visibility

## How
- Added shields.io badge at bottom of README

## Testing
- Badge displays correctly on GitHub

Closes #6
